### PR TITLE
Some videos have dashes in their id

### DIFF
--- a/src/angular-embedplayer.js
+++ b/src/angular-embedplayer.js
@@ -30,7 +30,7 @@ angular.module('videosharing-embed').factory('RegisteredPlayers', [ 'PlayerConfi
             whitelist: ['autoplay', 'controls', 'loop', 'playlist', 'rel'],
             playerID: 'www.youtube.com/embed/',
             protocol: 'http://',
-            playerRegExp: /(http:|https:)?\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)(\w*)(&(amp;)?[\w\?=]*)?/
+            playerRegExp: /(http:|https:)?\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\-\w]*)(&(amp;)?[\w\?=]*)?/
         },
         youtubeNoCookie: {
             options: {

--- a/test/modules/directives/embedvideoTest.js
+++ b/test/modules/directives/embedvideoTest.js
@@ -24,13 +24,13 @@ describe('embedVideo', function() {
 		it('should embed a youtube video', inject(function () {
 			inject(function ($compile) {
 				var rootElement;
-				rootElement = $compile('<a ng-href="http://www.youtube.com/watch?v=LOKyEt36Kjc" embed-video controls=0 >Watch</a>')(scope);
+				rootElement = $compile('<a ng-href="http://www.youtube.com/watch?v=-LOKyEt36Kjc" embed-video controls=0 >Watch</a>')(scope);
 				scope.$apply();
 				var element = rootElement[0].firstChild;
 				expect(element).toBeDefined();
 				expect(element.nodeName.toLowerCase()).toEqual('iframe');
 				var elementData = getURLandOptions(element.getAttribute('src'));
-				expect(elementData.url).toEqual('http://www.youtube.com/embed/LOKyEt36Kjc');
+				expect(elementData.url).toEqual('http://www.youtube.com/embed/-LOKyEt36Kjc');
 				expect(Object.keys(elementData.options).length).toEqual(3);
 				expect(elementData.options.loop).toEqual('0');
 				expect(elementData.options.controls).toEqual('0');


### PR DESCRIPTION
Example: https://www.youtube.com/watch?v=-IJ0uLh9UAs

The current regex doesn't match "-". Fixed
